### PR TITLE
Modifying the downloadURL to the raw file

### DIFF
--- a/dronePathTravelPlanner.user.js
+++ b/dronePathTravelPlanner.user.js
@@ -4,7 +4,7 @@
 // @category Tweaks
 // @version 0.8.0
 // @namespace	https://github.com/tehstone/IngressDronePath
-// @downloadURL	https://github.com/tehstone/IngressDronePath/blob/master/dronePathTravelPlanner.user.js
+// @downloadURL	https://github.com/tehstone/IngressDronePath/raw/master/dronePathTravelPlanner.user.js
 // @homepageURL	https://github.com/tehstone/IngressDronePath
 // @description Shows drone travel range from selected portal
 // @author tehstone


### PR DESCRIPTION
When updating the plugin from iitc-ce for Android (I've not tested that plugin in a browser yet), the content of the .user.json is replaced by the html page of the blob instead of the correct content of the raw.
With the correct URL, update should be working as intended.